### PR TITLE
Fixes Undo Button 

### DIFF
--- a/GNUChessActivity.py
+++ b/GNUChessActivity.py
@@ -529,7 +529,7 @@ class GNUChessActivity(activity.Activity):
 
     def _undo_cb(self, *args):
         # No undo while sharing
-        if self.collab.props.leader is None:
+        if self.playing_robot:
             self._gnuchess.undo()
 
     def _hint_cb(self, *args):

--- a/GNUChessActivity.py
+++ b/GNUChessActivity.py
@@ -529,7 +529,7 @@ class GNUChessActivity(activity.Activity):
 
     def _undo_cb(self, *args):
         # No undo while sharing
-        if self.playing_robot:
+        if (self.playing_robot or self.playing_mode) and not self._gnuchess.we_are_sharing:
             self._gnuchess.undo()
 
     def _hint_cb(self, *args):


### PR DESCRIPTION
@chimosky  @quozl This Pr fixes undo button of sugarchess while playing in Robot mode as well as in play with a person mode.
While looking for source code of the activity it is specified not to use undo button in sharing mode.This fixes #13 .